### PR TITLE
🔧 chore: 스토리북 GloblaStyle, theme 사용가능하도록 추가

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,19 @@
+import GlobalStyle from "@/styles/GlobalStyle";
+import { ThemeProvider } from "styled-components";
+import theme from "@/styles/theme";
+import { StylesProvider } from "@mui/styles";
+
+export const decorators = [
+  (Story) => (
+    <ThemeProvider theme={theme}>
+      <StylesProvider injectFirst>
+        <GlobalStyle />
+        <Story />
+      </StylesProvider>
+    </ThemeProvider>
+  ),
+];
+
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },
   controls: {
@@ -6,4 +22,4 @@ export const parameters = {
       date: /Date$/,
     },
   },
-}
+};


### PR DESCRIPTION
## 💻 작업 내역

- 스토리북에서 GloblaStyle, theme 자동 적용되도록 preview.js를 수정했습니다.

<br>

<!-- ## ❗ 변경사항 (변경사항 있을 시)

- 의존성 목록

<br> -->

## 🔎 PR 특이 사항 <!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->

```import GlobalStyle from "@/styles/GlobalStyle";
import { ThemeProvider } from "styled-components";
import theme from "@/styles/theme";
import { StylesProvider } from "@mui/styles";
```
스토리북에 위 코드가 적용된 채로 시작됩니다
