### PR TITLE
🔧 chore: 헤더 position fixed 및 배경색상 흰색 추가

### DIFF
--- a/src/components/base/Header.jsx
+++ b/src/components/base/Header.jsx
@@ -6,6 +6,9 @@ import PropTypes from "prop-types";
 import theme from "@/styles/theme";
 
 const Container = styled.div`
+  position: fixed;
+  top: 0;
+  background-color: white;
   display: flex;
   padding: 0rem 1rem;
   margin: 0.5rem 0rem;


### PR DESCRIPTION
## 💻 작업 내역

- 헤더 컴포넌트 Position: fixed;
- background-color: white;

위와 같이 두가지 사항 추가했습니다.

## 🔎 PR 특이 사항 <!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->

- 헤더 들어간 페이지 구현하신 분 계시다면 margin-top: 5rem; 추가 하시면 딱 적절하게 맞을 듯 합니다.
