### PR TITLE
🐛 fix : comments 데이터를 props로 받아 처리 코드로 수정

### DIFF
--- a/src/components/base/Profile.jsx
+++ b/src/components/base/Profile.jsx
@@ -1,10 +1,8 @@
 import Avatar from "@mui/material/Avatar";
 import AvatarGroup from "@mui/material/AvatarGroup";
-import CircularProgress from "@mui/material/CircularProgress";
-import Box from "@mui/material/Box";
 import PropTypes from "prop-types";
 import { makeStyles } from "@mui/styles";
-import useAsync from "../utils/hooks/useAsync";
+import { useState } from "react";
 
 const useStyles = makeStyles({
   avatar: ({ width, height }) => ({
@@ -13,87 +11,28 @@ const useStyles = makeStyles({
   }),
 });
 
-const wait = (timeToDelay) =>
-  new Promise((resolve) => setTimeout(resolve, timeToDelay));
-
-//dummy Data
-const dataArr = [
-  {
-    name: "mmmm",
-    image: "/",
-    id: "khw970421",
-  },
-  {
-    name: "김",
-    image: "/",
-    id: "khw97wdlwloed0",
-  },
-  {
-    name: "박",
-    image: "",
-    id: "kii9222swwsss",
-  },
-  {
-    name: "윤",
-    image: "",
-    id: "kqwjeowos11ss",
-  },
-  {
-    name: "윤",
-    image: "",
-    id: "kqwjeowos11ss",
-  },
-  {
-    name: "윤",
-    image: "",
-    id: "kqwjeowos11ss",
-  },
-  {
-    name: "윤",
-    image: "",
-    id: "kqwjeowos11ss",
-  },
-];
-
-// 사이즈 크기 자유롭게
-
-async function getUsers() {
-  await wait(1000);
-  return dataArr;
-}
-
-const Profile = ({ max, width, height }) => {
+const Profile = ({ max, width, height, comments = [] }) => {
   const classes = useStyles({ width, height });
-  const [state, refetch] = useAsync(getUsers, []);
-  const { loading, data: users, error } = state; // state.data 를 users 키워드로 조회
+  const [state, refetch] = useState(comments);
 
-  console.log(max, width, height, refetch);
-
+  console.log(state, refetch);
   //Avatar 태그 클릭시 이벤트
   const clickAvatarHandler = (id) => {
     //해당 대상의 마이페이지로 이동하는 함수 구현
     console.log(id);
   };
 
-  if (loading)
-    return (
-      <Box sx={{ display: "flex" }}>
-        <CircularProgress style={{ color: "#FD9F28", width, height }} />
-      </Box>
-    );
-  if (error) return <div>에러가 발생했습니다</div>;
-  if (!users) return null;
   return (
     <>
       <AvatarGroup max={max} classes={{ avatar: classes.avatar }}>
-        {users.map(({ name, image, id }) => {
+        {state.map(({ userName, userImage, userId }) => {
           return (
             <Avatar
-              key={id + Math.random()}
-              alt={name}
-              src={image}
+              key={userId + Math.random()}
+              alt={userName}
+              src={userImage}
               onClick={() => {
-                clickAvatarHandler(id);
+                clickAvatarHandler(userId);
               }}
             />
           );
@@ -102,17 +41,18 @@ const Profile = ({ max, width, height }) => {
     </>
   );
 };
-
 Profile.defaultProps = {
   max: 3,
   width: 40,
   height: 40,
+  comments: [],
 };
 
 Profile.propTypes = {
   max: PropTypes.number,
   width: PropTypes.number,
   height: PropTypes.number,
+  comments: PropTypes.array,
 };
 
 export default Profile;


### PR DESCRIPTION
## 💻 작업 내역

- 기존에 dummy_data를 props로 받아 처리할 수 있게 수정

### 예시

```js
<Profile
        comments={[
          {
            id: 1,
            comment: "기부신청",
            userId: 123,
            userName: "기부니1",
            userImage: "test.jpg",
            createdDate: "2021-12-14T00:38:39.943698",
            updatedDate: "2021-12-14T00:38:39.943698",
          },
          {
            id: 2,
            comment: "기부신청",
            userId: "abcdef",
            userName: "기부니2",
            userImage:
              "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c4/IU_at_%22Persona%22_press_conference%2C_27_March_2019_02.jpg/640px-IU_at_%22Persona%22_press_conference%2C_27_March_2019_02.jpg",
            createdDate: "2021-12-14T00:38:39.943698",
            updatedDate: "2021-12-14T00:38:39.943698",
          },
          {
            id: 3,
            comment: "기부신청",
            userId: 456,
            userName: "기부니3",
            userImage: "test.jpg",
            createdDate: "2021-12-14T00:38:39.943698",
            updatedDate: "2021-12-14T00:38:39.943698",
          },
        ]}
      />
```

### 결과
<img width="97" alt="image" src="https://user-images.githubusercontent.com/59253551/146033586-9cdda2a6-0aea-4db5-909a-7d481de0d335.png">


* 2번째 image가 있는 avatar는 사진이 나타나게 된다. 
