### PR TITLE
🐛 fix: 로그인 하지 않았을 때에도 관심센터목록을 불러오던 문제 수정

### DIFF
--- a/src/pages/WishesPage.jsx
+++ b/src/pages/WishesPage.jsx
@@ -10,6 +10,7 @@ import { getRequest } from "@/api/axios";
 import { Box } from "@mui/material";
 import BaseButton from "@/components/base/BaseButton";
 import LoadingCircular from "@/components/base/LoadingCircular";
+import jwt_decode from "jwt-decode";
 
 const WishesPage = () => {
   const state = useContext(StateContext);
@@ -21,7 +22,13 @@ const WishesPage = () => {
   const [favoriteList, setFavoriteList] = useState("");
 
   useEffect(async () => {
-    if (!localStorage.getItem("needit_access_token")) return;
+    if (
+      !localStorage.getItem("needit_access_token") ||
+      (!!localStorage.getItem("needit_access_token") &&
+        jwt_decode(localStorage.getItem("needit_access_token")).auth ===
+          "ROLE_CENTER")
+    )
+      return;
     const userFavorite = await getRequest("users");
     setFavoriteList(
       userFavorite.data.myFavorite.map((center) => center.centerId)

--- a/src/pages/WishesPage.jsx
+++ b/src/pages/WishesPage.jsx
@@ -21,6 +21,7 @@ const WishesPage = () => {
   const [favoriteList, setFavoriteList] = useState("");
 
   useEffect(async () => {
+    if (!localStorage.getItem("needit_access_token")) return;
     const userFavorite = await getRequest("users");
     setFavoriteList(
       userFavorite.data.myFavorite.map((center) => center.centerId)
@@ -47,7 +48,7 @@ const WishesPage = () => {
       <Header type="member" fixed />
       <TagFilter />
       <PostFilter />
-      {isLoading && favoriteList ? (
+      {isLoading ? (
         <>
           <PostContainer>
             {postList?.map((post, id) => {


### PR DESCRIPTION
## 💻 작업 내역

- 로그인 하지 않았을 때에도 관심센터목록을 불러와서, 토큰이 없을 때 멤버뷰를 접근하면 401에러가 뜨는 것을 해결했습니다.

<br>

<!-- ## ❗ 변경사항 (변경사항 있을 시)

- 의존성 목록

<br> -->
