### PR TITLE
✨ feature: 태그 미설정 시 자동으로 "기타"태그 설정

### DIFF
--- a/src/components/domain/Writes/Writes.jsx
+++ b/src/components/domain/Writes/Writes.jsx
@@ -144,7 +144,7 @@ const Writes = () => {
                 category,
                 content,
                 quality,
-                tags: apiTag,
+                tags: apiTag.length === 0 ? [10] : apiTag,
                 title,
               }),
             ],

--- a/src/utils/PrivateRoute.jsx
+++ b/src/utils/PrivateRoute.jsx
@@ -4,7 +4,6 @@ import PropTypes from "prop-types";
 
 function PrivateRoute({ children }) {
   const isLogin = !!localStorage.getItem("needit_access_token");
-  console.log(isLogin);
 
   return isLogin ? children : <Navigate to="/login" />;
 }


### PR DESCRIPTION
## 💻 작업 내역

- 태그없는 게시글이 불러오지 않아져서 일단 태그 미설정 시 자동으로 "기타"태그 설정되도록 했습니다.
- 다른 브랜치를 파야하지만,, privateroute에 있는 console.log를 지웟습니다

<br>

<!-- ## ❗ 변경사항 (변경사항 있을 시)

- 의존성 목록

<br> -->
