### PR TITLE
🐛 fix: 로그인 하지 않은 사용자일 때 상세조회 버그 해결

### DIFF
--- a/src/components/domain/Detail/Detail.jsx
+++ b/src/components/domain/Detail/Detail.jsx
@@ -21,6 +21,7 @@ import { getRequest, postRequest, deleteRequest } from "@/api/axios";
 import { useParams, Link } from "react-router-dom";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
+import UserType from "@/utils/hooks/UserType";
 const style = {
   position: "absolute",
   top: "50%",
@@ -152,7 +153,7 @@ const Detail = () => {
     await deleteRequest(`favorites/${detailData.userId}`);
   };
   const follow = async () => {
-    setFollowed(true);
+    UserType() === "member" && setFollowed(true);
     await postRequest(`favorites/${detailData.userId}`);
   };
 

--- a/src/components/domain/Detail/Detail.jsx
+++ b/src/components/domain/Detail/Detail.jsx
@@ -68,7 +68,10 @@ const Detail = () => {
     const writeApiData = noFilterWriteData.data;
     setDetailData(writeApiData);
 
-    if (!localStorage.getItem("needit_access_token")) return;
+    if (!localStorage.getItem("needit_access_token")) {
+      setIsLoading(true);
+      return;
+    }
     //user의 고유Id 저장
     const noFilterUserData = await getRequest(`users`);
     const userApiData = noFilterUserData.data;

--- a/src/utils/validateTokenExp.js
+++ b/src/utils/validateTokenExp.js
@@ -9,10 +9,10 @@ function validateTokenExp(error) {
       jwt_decode(localStorage.getItem("needit_access_token")).exp
   ) {
     localStorage.removeItem("needit_access_token");
+    history.pushState(null, null, "/login");
+    location.reload();
+    alert("로그인 유효시간이 만료되었습니다. \n로그인 화면으로 이동합니다");
   }
-  alert("로그인 유효시간이 만료되었습니다. \n로그인 화면으로 이동합니다");
-  history.pushState(null, null, "/login");
-  location.reload();
 }
 
 export default validateTokenExp;


### PR DESCRIPTION
## 💻 작업 내역

- 로그인 하지 않은 사용자일때도 로딩해제 로직을 추가하여 로그인 하지 않은 사용자 무한로딩 버그 해결
- validateTokenExp 토큰 만료시에만 동작하도록 수정
- `UserType==="member"` 일때에만 팔로우버튼 UI 동작하도록 수정

<br>

<!-- ## ❗ 변경사항 (변경사항 있을 시)

- 의존성 목록

<br> -->
